### PR TITLE
feat: Output directory as argument and updated cli params to be positional and keyword.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -50,48 +50,80 @@ struct cmpSort {
 
 const char PKG_MAGIC[4] = {0x7F, 0x43, 0x4E, 0x54};
 
-void merge(map<string, Package> packages) {
+char *get_argument_value(int argc, char *argv[], const char *arg_name) {
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], arg_name) == 0 && i + 1 < argc) {
+            return argv[i + 1]; // Return next argument as value
+        }
+    }
+    return NULL; // Return NULL if argument not found
+}
+
+void parse_arguments(
+    int argc,
+    char *argv[],
+    std::string &input,
+    std::string &output,
+    const std::string &input_flag,
+    const std::string &output_flag
+) {
+    input = "";
+    output = "";
+
+    int i = 1; // Start processing after program name
+
+    while (i < argc) {
+        if (argv[i] == input_flag && i + 1 < argc) {
+            input = argv[i + 1];
+            i += 2;
+        } else if (argv[i] == output_flag && i + 1 < argc) {
+            output = argv[i + 1];
+            i += 2;
+        } else if (input.empty()) {
+            input = argv[i];
+            i++;
+        } else if (output.empty()) {
+            output = argv[i];
+            i++;
+        } else {
+            i++; // Ignore unexpected arguments
+        }
+    }
+
+    // Default output to input if not set
+    if (!input.empty() && output.empty()) {
+        output = input;
+    }
+}
+
+void merge(map<string, Package> packages, const string &out_dir) {
     for (auto &root: packages) {
         auto pkg = root.second;
-
-        // Before we start, we need to sort the lists properly
-        // std::sort(pkg.parts.begin(), pkg.parts.end());
 
         size_t pieces = pkg.parts.size();
         auto title_id = root.first.c_str();
 
-        printf("[work] beginning to merge %d %s for package %s...\n", pieces, pieces == 1 ? "piece" : "pieces",
-               title_id);
+        printf("[work] beginning to merge %d %s for package %s...\n", pieces, pieces == 1 ? "piece" : "pieces", title_id);
 
         string merged_file_name = root.first + "-merged.pkg";
-        // string full_merged_file = pkg.file.parent_path().string() + "\\" + merged_file_name;
+        fs::path merged_file_path = fs::path(out_dir) / merged_file_name; // Use output directory
 
-        // fs::path dir (pkg.file.parent_path().string());
-        fs::path file(merged_file_name);
-
-        fs::path _full_merged_file = pkg.file.parent_path() / file;
-        string full_merged_file = _full_merged_file.string();
-
-        if (fs::exists(full_merged_file)) {
-            fs::remove(full_merged_file);
+        if (fs::exists(merged_file_path)) {
+            fs::remove(merged_file_path);
         }
 
         printf("\t[work] copying root package file to new file...");
-        auto merged_file = fs::path(full_merged_file);
-
-        // Deal with root file first
-        fs::copy_file(pkg.file, merged_file, fs::copy_options::update_existing);
+        fs::copy_file(pkg.file, merged_file_path, fs::copy_options::update_existing);
         printf("done\n");
 
-        // Using C API from here on because it just works and is fast
-        FILE *merged = fopen(full_merged_file.c_str(), "a+b");
+        FILE *merged = fopen(merged_file_path.string().c_str(), "a+b");
 
-        // Now all the pieces...
+        // Merge parts into the output file
         for (auto &part: pkg.parts) {
             FILE *to_merge = fopen(part.file.string().c_str(), "r+b");
-
             auto total_size = fs::file_size(part.file);
             assert(total_size != 0);
+
             char buffer[1024 * 512];
             uintmax_t copied = 0;
 
@@ -99,9 +131,8 @@ void merge(map<string, Package> packages) {
             while ((read_data = fread(buffer, sizeof(char), sizeof(buffer), to_merge)) > 0) {
                 fwrite(buffer, sizeof(char), read_data, merged);
                 copied += read_data * sizeof(char);
-                auto percentage = ((double) copied / (double) total_size) * 100;
-                printf("\r\t[work] merged %llu/%llu bytes (%.0lf%%) for part %d...", copied, total_size, percentage,
-                       part.part);
+                auto percentage = ((double)copied / (double)total_size) * 100;
+                printf("\r\t[work] merged %llu/%llu bytes (%.0lf%%) for part %d...", copied, total_size, percentage, part.part);
             }
             fclose(to_merge);
 
@@ -113,9 +144,15 @@ void merge(map<string, Package> packages) {
 
 int main(int argc, char *argv[]) {
     //////////////////////////////////
-    string dir;
+    std::string dir, out_dir;
 
-    if (argc < 2) {
+    // Dynamic flag names
+    std::string input_flag = "-i";
+    std::string output_flag = "-o";
+
+    parse_arguments(argc, argv, dir, out_dir, input_flag, output_flag);
+
+    if (dir.empty()) {
         // Open dialog
         NFD_Init();
 
@@ -150,7 +187,7 @@ int main(int argc, char *argv[]) {
         }
 
         NFD_Quit();
-    } else dir = argv[1];
+    }
 
     if (!fs::is_directory(dir)) {
         printf("[error] argument '%s' is not a directory\n", dir.c_str());
@@ -187,17 +224,17 @@ int main(int argc, char *argv[]) {
          * TODO: This throws compile error on Windows. Not sure why.
          * Check if it's root PKG
          */
-//        if(pkg_piece == 0){
-//            std::ifstream ifs(file, std::ios::binary);
-//            char magic[4];
-//            ifs.read(magic, sizeof(magic));
-//            ifs.close();
-//
-//            if (memcmp(magic, PKG_MAGIC, sizeof(PKG_MAGIC)) != 0) {
-//                printf("[warn] assumed root PKG file '%s' doesn't match PKG magic (is %s, wants %s). skipping...\n", file_name.c_str(), magic, PKG_MAGIC);
-//                continue;
-//            }
-//        }
+        //        if(pkg_piece == 0){
+        //            std::ifstream ifs(file, std::ios::binary);
+        //            char magic[4];
+        //            ifs.read(magic, sizeof(magic));
+        //            ifs.close();
+        //
+        //            if (memcmp(magic, PKG_MAGIC, sizeof(PKG_MAGIC)) != 0) {
+        //                printf("[warn] assumed root PKG file '%s' doesn't match PKG magic (is %s, wants %s). skipping...\n", file_name.c_str(), magic, PKG_MAGIC);
+        //                continue;
+        //            }
+        //        }
 
         auto _file = Files();
         _file.part = (int) pkg_piece;
@@ -228,7 +265,7 @@ int main(int argc, char *argv[]) {
         pkg->parts.push_back(piece);
     }
 
-    merge(packages);
+    merge(packages, out_dir);
     printf("\n[success] completed\n");
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -189,6 +189,10 @@ int main(int argc, char *argv[]) {
         NFD_Quit();
     }
 
+    if (out_dir.empty()) {
+        out_dir = dir;
+    }
+
     if (!fs::is_directory(dir)) {
         printf("[error] argument '%s' is not a directory\n", dir.c_str());
         return 1;


### PR DESCRIPTION
- Added optional output directory as argument.
- If output directory is not passed, then it default to input.
- Updated cli params to be positional and keyword. Example: `./pkg-merge -i "/Downloads" -o "/Desktop"` is the same as `./pkg-merge "/Downloads" "/Desktop"`.

If you pass `./pkg-merge -o "/Downloads"` then the modal to choose input directory will pop up.

> Running `./pkg-merge "/Downloads"` is the same as `./pkg-merge -i "/Downloads"`. No pop up.