### PR TITLE
Create CI file and macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,18 @@ name: macOS
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
-    tags: [ 'v*' ]
+    paths:
+      - '**'
+      - '!.github/**'
+      - '.github/workflows/build.yml'
+      - '!**.md'
+  
   pull_request:
-    branches: [ master ]
+    paths:
+      - '**'
+      - '!.github/**'
+      - '.github/workflows/build.yml'
+      - '!**.md'
 
 jobs:
   build-macOS:
@@ -32,7 +40,7 @@ jobs:
 
       - name: Build
         run: |
-          make -C build
+          make -C build-${{ matrix.suffix }}
 
       - name: Upload artifacts - macOS
         uses: actions/upload-artifact@v4
@@ -51,13 +59,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pkg-merge-macOS-arm64
-          path: build-arm64/pkg_merge
+          path: build-arm64
 
       - name: Download x86 Artifact
         uses: actions/download-artifact@v4
         with:
           name: pkg-merge-macOS-x86
-          path: build-x86/pkg_merge
+          path: build-x86
 
       - name: Create Univeral Binary
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: macOS
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  macOS:
+    
+    strategy:
+      matrix:
+        include:
+            - runner: macos-latest
+              suffix: arm64
+            - runner: macos-13
+              suffix: x86
+    runs-on: ${{ matrix.runner}}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check CMake version
+        run: cmake --version
+
+      - name: Configure
+        run: cmake . -B build 
+
+      - name: Build
+        run: make -C build
+
+      - name: Sign the app
+        run: codesign --sign - --force --deep build/pkg_merge
+
+      - name: Upload artifacts - macOS
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkg-merge-macOS-${{ matrix.suffix }}
+          path: build/pkg_merge
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,7 @@ on:
     branches: [ master ]
 
 jobs:
-  macOS:
-    
+  build-macOS:
     strategy:
       matrix:
         include:
@@ -29,17 +28,54 @@ jobs:
         run: cmake --version
 
       - name: Configure
-        run: cmake . -B build 
+        run: cmake . -B build-${{ matrix.suffix }}
 
       - name: Build
-        run: make -C build
-
-      - name: Sign the app
-        run: codesign --sign - --force --deep build/pkg_merge
+        run: |
+          make -C build
 
       - name: Upload artifacts - macOS
         uses: actions/upload-artifact@v4
         with:
           name: pkg-merge-macOS-${{ matrix.suffix }}
-          path: build/pkg_merge
+          path: build-${{ matrix.suffix }}/pkg_merge
           if-no-files-found: error
+
+  make-macOS-universal-binary:
+    name: macOS Universal Binary
+    needs: build-macOS
+    runs-on: macos-latest
+    
+    steps:
+      - name: Download Arm Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pkg-merge-macOS-arm64
+          path: build-arm64/pkg_merge
+
+      - name: Download x86 Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pkg-merge-macOS-x86
+          path: build-x86/pkg_merge
+
+      - name: Create Univeral Binary
+        run: |
+          mkdir bin
+          lipo -output bin/pkg_merge -create build-arm64/pkg_merge build-x86/pkg_merge
+          mv bin/pkg_merge pkg_merge
+          chmod +rxw pkg_merge
+          tar cv pkg_merge | gzip -9 > pkg_merge-macOS-Universal.tar.gz
+  
+      - name: Delete x86 and Arm builds
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: |
+            pkg-merge-macOS-x86
+            pkg-merge-macOS-arm64
+
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkg_merge-macOS-Universal
+          path: pkg_merge-macOS-Universal.tar.gz


### PR DESCRIPTION
Adds a `build.yml` file for CI.

Initial commit produces arm64 and x86 builds for macOS.

Edit: 
- Updated the PR to produce a universal binary.
- Changed the workflow dispatch, because I was not able to trigger action builds with my test branches